### PR TITLE
fix: make scripts run on systems without /bin/bash

### DIFF
--- a/backend/build.sh
+++ b/backend/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 echo "Compiling the TCF Spring BACKEND within a multi-stage docker build"
 

--- a/backend/run-postgres-out-of-docker-compose.sh
+++ b/backend/run-postgres-out-of-docker-compose.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # postgres
 docker run --name postgresql-local -p 127.0.0.1:5432:5432 -e POSTGRES_USER=postgresuser -e POSTGRES_PASSWORD=postgrespass -e POSTGRES_DB=tcf-db -d postgres:16.1

--- a/backend/run.sh
+++ b/backend/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Running the image as
 #  - removing the container after exit (ease housekeeping because it's a POC)

--- a/bank/build.sh
+++ b/bank/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 echo "Compiling the NestJS Bank system within a multi-stage docker build"
 

--- a/bank/run.sh
+++ b/bank/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Running the image as
 #  - removing the container after exit,

--- a/build-all.sh
+++ b/build-all.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 function build_dir()  # $1 is the dir to get it
 {

--- a/cli/build.sh
+++ b/cli/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 echo "Compiling the TCF Spring CLI within a multi-stage docker build"
 


### PR DESCRIPTION
Hello. See [this SO thread](https://stackoverflow.com/questions/21612980/why-is-usr-bin-env-bash-superior-to-bin-bash) for more details

To sum it up:

> #!/usr/bin/env searches PATH for bash, and bash is not always in /bin, particularly on non-Linux systems. For example, on my OpenBSD system, it's in /usr/local/bin, since it was installed as an optional package.